### PR TITLE
add unit test coverage support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,57 @@
 language: rust
+cache: cargo
+
 rust:
   - stable
   - beta
-  - nightly
-before_script:
-  - rustup component add clippy
-  - rustup component add rustfmt
-jobs:
-  allow_failures:
-    - rust: nightly
-  fast_finish: true
+
 os:
   - linux
   - osx
   - windows
+
+before_script:
+  - rustup component add clippy
+  - rustup component add rustfmt
+
 script:
   - RUSTFLAGS="-D warnings" cargo build --verbose
   - cargo test --verbose
   - cargo clippy -- -D warnings
   - cargo fmt --all -- --check
+
+jobs:
+  fast_finish: true
+  allow_failures:
+    - rust: nightly
+  # The stable Linux build uploads results to Coveralls.
+  exclude:
+    - rust: stable
+      os: linux
+  include:
+    - rust: stable
+      os: linux
+      addons:
+        # Dependencies of kcov, used for cargo-travis.
+        apt:
+          packages:
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - binutils-dev
+            - cmake
+          sources:
+            - kalakris-cmake
+      before_script:
+        - cargo install --force cargo-travis
+        - export PATH=$HOME/.cargo/bin:$PATH
+        - rustup component add clippy
+        - rustup component add rustfmt
+      after_success:
+        - cargo coveralls
+    # A basic check is done for the nightly version of Rust
+    - rust: nightly
+      os: linux
+      script:
+       - RUSTFLAGS="-D warnings" cargo build --verbose
+       - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,11 @@ jobs:
           sources:
             - kalakris-cmake
       before_script:
-        - cargo install --force cargo-travis
+        # Install / update outdated cached binaries.
         - export PATH=$HOME/.cargo/bin:$PATH
+        - cargo install cargo-update || echo "cargo-update already installed"
+        - cargo install cargo-travis || echo "cargo-travis already installed"
+        - cargo install-update -a
         - rustup component add clippy
         - rustup component add rustfmt
       after_success:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,13 +28,13 @@ If you have an idea for a new feature file a feature request then assign it
 to yourself to start work. This ensures others have clarity of new features
 being added to the library.
 
-Also, pull requests adding, clarifying, or fixing typos in the documentation is
-always welcome.
+Also, pull requests for adding, clarifying, or fixing typos in the 
+documentation are always welcome.
 
 
 ## Unit Tests
-A goal of the library is to maintain excellent test coverage to ensure we 
-deliver a quality product. We strive for 100% branch coverage.
+A goal of this project is to maintain excellent test coverage to ensure we 
+deliver a quality library. We strive for 100% branch coverage.
 
 Please ensure any added code is covered with unit tests and the unit tests
 pass before sending a pull request.
@@ -62,16 +62,16 @@ Then run with:
 cargo clippy
 ```
 
-This will point out any problematic spots in the code. Please fix any items it points out.
-Rarely, it might have a false positive. In that case please allow an exception for the
+This will point out any problematic spots in the code. Please fix the indicated items.
+Rarely, there might be false positive. In that case please allow an exception for the
 specific rule at the specific location of the violation along with a comment describing
 why it was necessary to suppress the rule.
 
 
 ## Code Formatting
 The [rustfmt](https://github.com/rust-lang/rustfmt) to is used to automatically provide
-consistent formatting to the code base. This allows you to focus on the hight level logic
-of the code and not worry about the formatting details. To instal `rustfmt` run:
+consistent formatting to the code base. This allows you to focus on the high level logic
+and not worry about formatting details. To instal `rustfmt` run:
 
 ```
 rustup component add rustfmt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+# Contributing
+Contributions to the library welcome! This page describes how to get started
+developing for this library.
+
+This guide describes the tools and procedures used to ensure work is done 
+efficiently while maintaining consistent code quality. Don't worry if this
+guide seems overwhelming; we use automated tools to check pull requests
+so you do not have to worry if a step is accidentally skipped.
+
+
+## Getting Started
+This library is developed using the [Rust programming language](https://www.rust-lang.org/).
+Install Rust then build and test the library using `cargo`:
+
+```
+cargo test
+```
+
+All the tests should pass and you are ready to start modifying code.
+
+If you are new to Rust, [The Rust Programming Language](https://doc.rust-lang.org/stable/book/)
+book is a great place to start learning about the language.
+
+
+## What to Work On
+Feel free to take a look at the issue tracker for tasks and bugs to tackle.
+If you have an idea for a new feature file a feature request then assign it
+to yourself to start work. This ensures others have clarity of new features
+being added to the library.
+
+Also, pull requests adding, clarifying, or fixing typos in the documentation is
+always welcome.
+
+
+## Unit Tests
+A goal of the library is to maintain excellent test coverage to ensure we 
+deliver a quality product. We strive for 100% branch coverage.
+
+Please ensure any added code is covered with unit tests and the unit tests
+pass before sending a pull request.
+
+In general, unit tests should conform to the following:
+
+* There is a single `assert` statement in the test.
+* There are no branches in the test; e.g. no `if`, `while`, or other such statements.
+* The names following the format: unit of work **when** state under test **should** expected behavior.
+
+See the existing unit tests for examples.
+
+
+## Lint with Clippy
+We use [Clippy](https://github.com/rust-lang/rust-clippy) to catch common
+mistakes in Rust code. This tool can be installed by running:
+
+```
+rustup component add clippy
+```
+
+Then run with:
+
+```
+cargo clippy
+```
+
+This will point out any problematic spots in the code. Please fix any items it points out.
+Rarely, it might have a false positive. In that case please allow an exception for the
+specific rule at the specific location of the violation along with a comment describing
+why it was necessary to suppress the rule.
+
+
+## Code Formatting
+The [rustfmt](https://github.com/rust-lang/rustfmt) to is used to automatically provide
+consistent formatting to the code base. This allows you to focus on the hight level logic
+of the code and not worry about the formatting details. To instal `rustfmt` run:
+
+```
+rustup component add rustfmt
+```
+
+Then before you commit any code run:
+
+```
+cargo fmt
+```
+
+
+## Commits
+Please try to keep commits small and containing a single logical change.
+
+Consider these seven rules when writing a git commit message: 
+
+1. Separate subject from body with a blank line
+2. Limit the subject line to 50 characters
+3. Capitalize the subject line
+4. Do not end the subject line with a period
+5. Use the imperative mood in the subject line
+6. Wrap the body at 72 characters
+7. Use the body to explain what and why vs. how
+
+The excellent [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) 
+guide provides additional details and examples for each of these items.
+
+
+## Pull Requests
+When the change you worked on is complete please review the following checklist
+before sending a pull request:
+
+* Tests have been added for new code
+* Any new public APIs have been fully documented
+* Library builds with no warnings
+* All tests pass
+* Clippy reports no problems
+* rustfmt has been run to automatically format the code

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # open_ttt_lib
 [![Build Status](https://travis-ci.com/j-richey/open_ttt_lib.svg?branch=master)](https://travis-ci.com/j-richey/open_ttt_lib)
+[![Coverage Status](https://coveralls.io/repos/github/j-richey/open_ttt_lib/badge.svg?branch=master)](https://coveralls.io/github/j-richey/open_ttt_lib?branch=master)
 
 Open source Rust library that provides common Tic Tac Toe logic that can be used
 by other Rust applications.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ by other Rust applications.
 to [crates.io](https://crates.io/).
 
 
+## Feature Requests
+Feel free to request new features. File a feature request describing the feature
+you would like and what benefit you will get from the feature. A user story is 
+one way to capture this information:
+
+> As a **user** I want **goal/desire** so that **benefit**.
+
+
 ## Reporting Issues
 If you find an issue please include the following information in your report:
 
@@ -18,27 +26,10 @@ If you find an issue please include the following information in your report:
 * Version of the library being used.
 
 
-## Developing
-This library is developed using the [Rust programming language](https://www.rust-lang.org/).
-Once Rust is installed on your system you can build and test the library with `cargo`:
-
-```
-cargo test
-```
-
-All pull requests are checked with [Clippy](https://github.com/rust-lang/rust-clippy)
-and [rustfmt](https://github.com/rust-lang/rustfmt) to help ensure code
-consistency and quality.
-
-These tools can be installed and run locally with:
-
-```
-rustup component add clippy
-rustup component add rustfmt
-cargo clippy
-cargo fmt
-```
+## Contributing
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how
+to contribute to this project.
 
 
 ## License
-This library is licensed under the [MIT license](LICENSE.txt).
+The library is licensed under the [MIT license](LICENSE.txt).

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+# Code Complete recommends a max cyclomatic complexity of 10. 
+# For situations where more complex code is needed please 
+# include a comment of why it is needed in that situation.
+cognitive-complexity-threshold = 10


### PR DESCRIPTION
Pull request that enables checking code coverage and publishing to Coveralls.

Some other project level clean up and enhancements are contained in this pull request such as clarifying how to contribute and adding stricter Clippy checks.

See:  issue #21 