### PR TITLE
Replace kcov with tarpaulin for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,53 +10,36 @@ os:
   - osx
   - windows
 
-before_script:
-  - rustup component add clippy
-  - rustup component add rustfmt
-
-script:
-  - RUSTFLAGS="-D warnings" cargo build --all-targets --verbose
-  - cargo test --verbose
-  - cargo test --examples --verbose
-  - cargo clippy -- -D warnings
-  - cargo clippy --examples -- -D warnings
-  - cargo fmt --all -- --check
+addons:
+    apt:
+        packages:
+            - libssl-dev
 
 jobs:
   fast_finish: true
   allow_failures:
     - rust: nightly
-  # The stable Linux build uploads results to Coveralls.
-  exclude:
-    - rust: stable
-      os: linux
   include:
-    - rust: stable
-      os: linux
-      addons:
-        # Dependencies of kcov, used for cargo-travis.
-        apt:
-          packages:
-            - libcurl4-openssl-dev
-            - libelf-dev
-            - libdw-dev
-            - binutils-dev
-            - cmake
-          sources:
-            - kalakris-cmake
-      before_script:
-        # Install / update outdated cached binaries.
-        - export PATH=$HOME/.cargo/bin:$PATH
-        - cargo install cargo-update || echo "cargo-update already installed"
-        - cargo install cargo-travis || echo "cargo-travis already installed"
-        - cargo install-update -a
-        - rustup component add clippy
-        - rustup component add rustfmt
-      after_success:
-        - cargo coveralls
-    # A basic check is done for the nightly version of Rust
     - rust: nightly
       os: linux
-      script:
-       - RUSTFLAGS="-D warnings" cargo build --all-targets --verbose
-       - cargo test --verbose
+
+before_script: |
+  rustup component add clippy
+  rustup component add rustfmt
+
+  if [ "${TRAVIS_RUST_VERSION}" == stable ] && [ "${TRAVIS_OS_NAME}" == linux ]; then
+    cargo install cargo-tarpaulin
+  fi
+
+script: |
+  RUSTFLAGS="-D warnings" cargo build --all-targets --verbose
+  cargo test --verbose
+  cargo test --examples --verbose
+  cargo clippy -- -D warnings
+  cargo clippy --examples -- -D warnings
+  cargo fmt --all -- --check
+
+after_success: |
+  if [ "${TRAVIS_RUST_VERSION}" == stable ] && [ "${TRAVIS_OS_NAME}" == linux ]; then
+    cargo tarpaulin --ciserver travis-ci --coveralls ${TRAVIS_JOB_ID}
+  fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,25 @@ In general, unit tests should conform to the following:
 
 See the existing unit tests for examples.
 
+### Test Coverage with Tarpaulin
+If you are developing on Linux with a x86_64 processor you can measure the
+test coverage using [tarpaulin](https://crates.io/crates/cargo-tarpaulin).
+
+Install tarpaulin with the following:
+```
+cargo install cargo-tarpaulin
+```
+
+Then run with:
+```
+cargo tarpaulin --out Html
+```
+
+Open the generated `tarpaulin-report.html` file in your browser to view test
+coverage data.
+
+This tool is also automatically run as part of the pull request process.
+
 
 ## Lint with Clippy
 We use [Clippy](https://github.com/rust-lang/rust-clippy) to catch common


### PR DESCRIPTION
The build was using the cargo-travis along with kcov to generate
coverage data and submit it to coveralls. Unfortunately, this stopped
working due to a Rust update (https://github.com/roblabla/cargo-travis/issues/66).
Additionally, it was difficult to run this tool locally.

This pull request uses cargo-tarpaulin to generate the test coverage data and
upload it to coveralls. Additionally, developers with Linux can easily
generate coverage reports locally with tarpaulin. The CONTRIBUTING file
is updated with instructions on how to generate coverage reports.

See issue #33.