### PR TITLE
Issue 29 improve worst case AI move time by 150x.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,7 @@ Maintainers, please follow this checklist to create a release and publish it to
 4. Ensure checks pass by running the following:
    ```
    cargo test
+   cargo test --release -- --ignored
    cargo clippy -- -D warnings
    cargo fmt --all -- --check
    ```

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -70,8 +70,8 @@ fn perfect_ai_moves_benchmarks(c: &mut Criterion) {
 criterion_group!(game_bench, complete_game_benchmark);
 
 criterion_group!(
-    name = perfect_ai_bench; 
-    config = Criterion::default().sample_size(10); 
+    name = perfect_ai_bench;
+    config = Criterion::default().sample_size(50);
     targets = perfect_ai_moves_benchmarks);
 
 criterion_main!(game_bench, perfect_ai_bench);

--- a/examples/single_player.rs
+++ b/examples/single_player.rs
@@ -20,7 +20,7 @@ characters are used for the game board's display:
   X - Player 'X' owns the square.
   O - Player 'O' owns the square.
   w - The AI opponent will win if it places its mark at this location.
-  l - The AI opponent could loose if it places its mark at this location.
+  l - The AI opponent could lose if it places its mark at this location.
   c - This location leads to a cat's game --- neither player wins.
   ? - The AI opponent could not determine the outcome of this location.
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,0 +1,56 @@
+use open_ttt_lib::{ai, game};
+
+// Ensures the flawless AI never loses.
+//
+// The flawless AI fully evaluates every possible move and countermove to pick
+// the best position. However, if there is an issue, it might lose to a random
+// AI. This test plays several games to ensure the flawless AI does not lose.
+//
+// This test could take a while to exercise so it is disabled by default.
+#[test]
+#[ignore]
+fn flawless_ai_should_never_lose() {
+    // The number of games to play. A larger number makes the test take longer
+    // to run, but due to the random nature of the test, more likely to find
+    // any possible issues.
+    const NUM_GAMES: usize = 100;
+
+    let mut game = game::Game::new();
+
+    let random_ai = ai::Opponent::new(1.0);
+    let flawless_ai = ai::Opponent::new(0.0);
+
+    for _ in 0..NUM_GAMES {
+        let mut move_log = Vec::new();
+        loop {
+            match game.state() {
+                game::State::PlayerXMove => {
+                    let position = random_ai.get_move(&game).unwrap();
+                    move_log.push(format!("  Random AI as X: {:?}", position));
+                    game.do_move(position).unwrap();
+                }
+                game::State::PlayerOMove => {
+                    let position = flawless_ai.get_move(&game).unwrap();
+                    move_log.push(format!("  Flawless AI as O: {:?}", position));
+                    game.do_move(position).unwrap();
+                }
+                game::State::PlayerXWin(_) => {
+                    panic!(
+                        "\nThe random AI has won over the flawless AI. \
+                        \n\nList of moves: \n{}\n \
+                        \nThe final game board: \n{}\n",
+                        move_log.join("\n"),
+                        game.board()
+                    );
+                }
+                game::State::PlayerOWin(_) => {
+                    break;
+                }
+                game::State::CatsGame => {
+                    break;
+                }
+            };
+        }
+        game.start_next_game();
+    }
+}


### PR DESCRIPTION
Pull request for issue #29 that improves the worst case AI move time by 150x. This was accomplished by reducing the number of nodes that needed to be evaluated to determine the outcome of a game from over 600,000 to less than 9,000. See [callgrind-optimized.pdf](https://github.com/j-richey/open_ttt_lib/files/4777472/callgrind-optimized.pdf) for the callgrind output from these changes.

Two techniques were used to accomplish the performance improvement. 

First, we know the outcomes for all positions in a new games are always cat's games. The code was updated to detect a new game and returned the cached result.

Second, while evaluating a branch, if the worst outcome is found there is no need to continue evaluating other child nodes.  Instead, the worst outcome is propagated up the tree.

The graph below shows how each of the above changes changed the benchmarks both individally and combined.

![times-optimized](https://user-images.githubusercontent.com/49895469/84607793-1aee2a00-ae64-11ea-85ac-2b6279bf66c4.png) 

Note: the benchmarks were run on a  AMD Ryzen 7 2700x.  As shown, both the required worst cast time of 100ms and the desired worst case time of 10ms are far exceeded by the changes in this pull request.
