### PR TITLE
Use `Self` in enum methods instead of typename

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -324,12 +324,12 @@ impl Difficulty {
     // indicates if the `Opponent` should evaluate the current node.
     fn should_evaluate_node(&self, depth: i32) -> bool {
         match self {
-            Difficulty::None => Difficulty::none_should_evaluate_node(),
-            Difficulty::Easy => Difficulty::easy_should_evaluate_node(depth),
-            Difficulty::Medium => Difficulty::medium_should_evaluate_node(depth),
-            Difficulty::Hard => Difficulty::hard_should_evaluate_node(depth),
-            Difficulty::Unbeatable => Difficulty::unbeatable_should_evaluate_node(),
-            Difficulty::Custom(custom_should_evaluate_node) => custom_should_evaluate_node(depth),
+            Self::None => Difficulty::none_should_evaluate_node(),
+            Self::Easy => Difficulty::easy_should_evaluate_node(depth),
+            Self::Medium => Difficulty::medium_should_evaluate_node(depth),
+            Self::Hard => Difficulty::hard_should_evaluate_node(depth),
+            Self::Unbeatable => Difficulty::unbeatable_should_evaluate_node(),
+            Self::Custom(custom_should_evaluate_node) => custom_should_evaluate_node(depth),
         }
     }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -526,19 +526,19 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Error::GameOver => write!(
+            Self::GameOver => write!(
                 f,
                 "The game is over so no more moves can \
                  be performed. Use start_next_game() to start the next game."
             ),
-            Error::PositionAlreadyOwned(position, owner) => write!(
+            Self::PositionAlreadyOwned(position, owner) => write!(
                 f,
                 "The square at {:?} is already owned by {:?}. Once a square is \
                  owned by a player it cannot be used by a different player. Use \
                  free_positions() to get available positions that can be used.",
                 position, owner
             ),
-            Error::InvalidPosition(position) => write!(
+            Self::InvalidPosition(position) => write!(
                 f,
                 "The position {:?} is outside the area of the board. Please use \
                  a valid position contained by the board.",
@@ -591,11 +591,11 @@ impl State {
     /// ```
     pub fn is_game_over(&self) -> bool {
         match self {
-            State::PlayerXMove => false,
-            State::PlayerOMove => false,
-            State::PlayerXWin(_) => true,
-            State::PlayerOWin(_) => true,
-            State::CatsGame => true,
+            Self::PlayerXMove => false,
+            Self::PlayerOMove => false,
+            Self::PlayerXWin(_) => true,
+            Self::PlayerOWin(_) => true,
+            Self::CatsGame => true,
         }
     }
 }


### PR DESCRIPTION
Using `Self` in the enum implementation methods reduces duplicating the
enums name hopefully leading to more maintainable and concise code.

This pull request does not change any functionality.