### PR TITLE
Fix pedantic clippy warnings

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -488,7 +488,7 @@ pub fn best_position<S: BuildHasher>(
         Outcome::Unknown,
         Outcome::Loss,
     ];
-    for outcome in best_to_worst_outcomes.iter() {
+    for outcome in &best_to_worst_outcomes {
         if outcome_to_position_map.contains_key(outcome) {
             let random_position = **outcome_to_position_map
                 .get(outcome)
@@ -544,7 +544,7 @@ fn is_worst_outcome(outcome: Outcome, is_my_turn: bool) -> bool {
 // outcomes.
 fn worst_outcome(outcomes: &HashSet<Outcome>, is_my_turn: bool) -> Outcome {
     // Search through the outcomes, from worst to best, returning the first one found.
-    for outcome in worst_to_best_outcomes(is_my_turn).iter() {
+    for outcome in &worst_to_best_outcomes(is_my_turn) {
         if outcomes.contains(outcome) {
             return *outcome;
         }

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -114,7 +114,7 @@ impl Opponent {
             // Determine which player the AI is playing as. Note: we can only
             // determine the AI player if the game is not over, thus we rely on
             // the get_cached_result() call above to handle game over conditions.
-            let ai_player = AIPlayer::from_game_state(game.state());
+            let ai_player = AiPlayer::from_game_state(game.state());
 
             // For each free square, evaluate the consequences of using that
             // square. The outcome for each position and the position is recorded.
@@ -149,7 +149,7 @@ impl Opponent {
         &self,
         game: &game::Game,
         position: game::Position,
-        ai_player: AIPlayer,
+        ai_player: AiPlayer,
         depth: i32,
     ) -> Outcome {
         // Since this is a recursive function, ensure we have not made a mistake
@@ -179,7 +179,7 @@ impl Opponent {
 
         // Check to see if this position is being considered for this AI instance
         // or the if we are simulating the move for the other player.
-        let is_my_turn = ai_player == AIPlayer::from_game_state(game.state());
+        let is_my_turn = ai_player == AiPlayer::from_game_state(game.state());
 
         // Clone the game so we can try out the move without modifying the original game.
         let mut game = game.clone();
@@ -396,16 +396,16 @@ impl Outcome {
     // provided game state.
     //
     // Panics if the game is not over.
-    fn from_game_state(state: game::State, ai_player: AIPlayer) -> Self {
+    fn from_game_state(state: game::State, ai_player: AiPlayer) -> Self {
         match state {
             game::State::CatsGame => Outcome::CatsGame,
             game::State::PlayerXWin(_) => match ai_player {
-                AIPlayer::PlayerX => Outcome::Win,
-                AIPlayer::PlayerO => Outcome::Loss,
+                AiPlayer::PlayerX => Outcome::Win,
+                AiPlayer::PlayerO => Outcome::Loss,
             },
             game::State::PlayerOWin(_) => match ai_player {
-                AIPlayer::PlayerX => Outcome::Loss,
-                AIPlayer::PlayerO => Outcome::Win,
+                AiPlayer::PlayerX => Outcome::Loss,
+                AiPlayer::PlayerO => Outcome::Win,
             },
             _ => panic!(
                 "Cannot determine the AI outcome since the game is not over. \
@@ -417,12 +417,12 @@ impl Outcome {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-enum AIPlayer {
+enum AiPlayer {
     PlayerX,
     PlayerO,
 }
 
-impl AIPlayer {
+impl AiPlayer {
     // Determines which player the AI is playing as, X or O, based on the current
     // state of the game.
     //
@@ -915,9 +915,9 @@ mod tests {
     #[test]
     fn ai_player_from_game_state_when_player_X_move_should_be_player_X() {
         let game_state = game::State::PlayerXMove;
-        let expected_ai_player = AIPlayer::PlayerX;
+        let expected_ai_player = AiPlayer::PlayerX;
 
-        let actual_ai_player = AIPlayer::from_game_state(game_state);
+        let actual_ai_player = AiPlayer::from_game_state(game_state);
 
         assert_eq!(expected_ai_player, actual_ai_player);
     }
@@ -925,9 +925,9 @@ mod tests {
     #[test]
     fn ai_player_from_game_state_when_player_O_move_should_be_player_O() {
         let game_state = game::State::PlayerOMove;
-        let expected_ai_player = AIPlayer::PlayerO;
+        let expected_ai_player = AiPlayer::PlayerO;
 
-        let actual_ai_player = AIPlayer::from_game_state(game_state);
+        let actual_ai_player = AiPlayer::from_game_state(game_state);
 
         assert_eq!(expected_ai_player, actual_ai_player);
     }
@@ -938,13 +938,13 @@ mod tests {
         // Set the game state to a game over state.
         let game_state = game::State::CatsGame;
 
-        let _actual_ai_player = AIPlayer::from_game_state(game_state);
+        let _actual_ai_player = AiPlayer::from_game_state(game_state);
     }
 
     #[test]
     fn outcome_from_game_state_when_cats_game_should_be_cats_game() {
         let game_state = game::State::CatsGame;
-        let ai_player = AIPlayer::PlayerX;
+        let ai_player = AiPlayer::PlayerX;
         let expected_outcome = Outcome::CatsGame;
 
         let actual_outcome = Outcome::from_game_state(game_state, ai_player);
@@ -955,7 +955,7 @@ mod tests {
     #[test]
     fn outcome_from_game_state_when_player_X_win_and_player_X_should_be_win() {
         let game_state = game::State::PlayerXWin(Default::default());
-        let ai_player = AIPlayer::PlayerX;
+        let ai_player = AiPlayer::PlayerX;
         let expected_outcome = Outcome::Win;
 
         let actual_outcome = Outcome::from_game_state(game_state, ai_player);
@@ -966,7 +966,7 @@ mod tests {
     #[test]
     fn outcome_from_game_state_when_player_X_win_and_player_O_should_be_loss() {
         let game_state = game::State::PlayerXWin(Default::default());
-        let ai_player = AIPlayer::PlayerO;
+        let ai_player = AiPlayer::PlayerO;
         let expected_outcome = Outcome::Loss;
 
         let actual_outcome = Outcome::from_game_state(game_state, ai_player);
@@ -977,7 +977,7 @@ mod tests {
     #[test]
     fn outcome_from_game_state_when_player_O_win_and_player_O_should_be_win() {
         let game_state = game::State::PlayerOWin(Default::default());
-        let ai_player = AIPlayer::PlayerO;
+        let ai_player = AiPlayer::PlayerO;
         let expected_outcome = Outcome::Win;
 
         let actual_outcome = Outcome::from_game_state(game_state, ai_player);
@@ -988,7 +988,7 @@ mod tests {
     #[test]
     fn outcome_from_game_state_when_player_O_win_and_player_X_should_be_loss() {
         let game_state = game::State::PlayerOWin(Default::default());
-        let ai_player = AIPlayer::PlayerX;
+        let ai_player = AiPlayer::PlayerX;
         let expected_outcome = Outcome::Loss;
 
         let actual_outcome = Outcome::from_game_state(game_state, ai_player);

--- a/src/game.rs
+++ b/src/game.rs
@@ -598,11 +598,8 @@ impl State {
     /// ```
     pub fn is_game_over(&self) -> bool {
         match self {
-            Self::PlayerXMove => false,
-            Self::PlayerOMove => false,
-            Self::PlayerXWin(_) => true,
-            Self::PlayerOWin(_) => true,
-            Self::CatsGame => true,
+            Self::PlayerXMove | Self::PlayerOMove => false,
+            Self::PlayerXWin(_) | Self::PlayerOWin(_) | Self::CatsGame => true,
         }
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -220,7 +220,7 @@ impl Game {
 
     /// Marks the indicated square as being owned by the current player.
     ///
-    /// The state of the game is updated as a side effect of do_move(). The new
+    /// The state of the game is updated as a side effect of `do_move()`. The new
     /// state is returned if the move was successful.
     ///
     /// # Errors
@@ -341,7 +341,18 @@ impl Game {
         );
         let mut winning_positions = HashSet::with_capacity(MAX_WINNING_POSITIONS);
 
-        // Check for winning a row.
+        // Check for winning a rows, columns, or diagonals. Each function writes winning positions to
+        // the provided set.
+        self.check_rows(&mut winning_positions);
+        self.check_columns(&mut winning_positions);
+        self.check_top_left_to_bottom_right(&mut winning_positions);
+        self.check_top_right_to_bottom_left(&mut winning_positions);
+
+        winning_positions
+    }
+
+    // Helper function for checking for a winning row.
+    fn check_rows(&self, mut winning_positions: &mut HashSet<Position>) {
         for row in 0..self.board.size().rows {
             let starting_position = board::Position { row, column: 0 };
             let next_position_fn = |x: board::Position| board::Position {
@@ -350,8 +361,10 @@ impl Game {
             };
             self.check_sequence(&mut winning_positions, starting_position, next_position_fn);
         }
+    }
 
-        // Check for winning a column.
+    // Helper function for checking for a winning column.
+    fn check_columns(&self, mut winning_positions: &mut HashSet<Position>) {
         for column in 0..self.board.size().columns {
             let starting_position = board::Position { row: 0, column };
             let next_position_fn = |x: board::Position| board::Position {
@@ -360,24 +373,26 @@ impl Game {
             };
             self.check_sequence(&mut winning_positions, starting_position, next_position_fn);
         }
+    }
 
-        // Check for winning top left to bottom right.
+    // Helper function for checking the top left to bottom right diagonal.
+    fn check_top_left_to_bottom_right(&self, mut winning_positions: &mut HashSet<Position>) {
         let starting_position = board::Position { row: 0, column: 0 };
         let next_position_fn = |x: board::Position| board::Position {
             row: x.row + 1,
             column: x.column + 1,
         };
         self.check_sequence(&mut winning_positions, starting_position, next_position_fn);
+    }
 
-        // Check for top right to bottom left.
+    // Helper function for checking the top right to bottom left diagonal.
+    fn check_top_right_to_bottom_left(&self, mut winning_positions: &mut HashSet<Position>) {
         let starting_position = board::Position { row: 0, column: 2 };
         let next_position_fn = |x: board::Position| board::Position {
             row: x.row + 1,
             column: x.column - 1,
         };
         self.check_sequence(&mut winning_positions, starting_position, next_position_fn);
-
-        winning_positions
     }
 
     // Helper function for checking a sequence of positions.


### PR DESCRIPTION
Fixes several pedantic clippy warnings that are not on by default.  

These warnings occasionally caused the nightly Rust build to fail indicating these might be promoted to more prominent warnings in the future. Also, the changes result in easier to read code.

The following was used to run clippy: 
```
cargo clippy -- -W clippy::pedantic
```

Warnings fixed include: 
* upper_case_acronyms
* explicit_iter_loop
* match_same_arms
* shadow_unrelated